### PR TITLE
Add dedicated publications page

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         <div class="collapse navbar-collapse" id="navbarText">
           <ul class="navbar-nav">
             <li class="nav-item">
-              <a class="nav-link" href="#publications">Publications</a>
+              <a class="nav-link" href="publications.html">Publications</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="#contact">Contact</a>
@@ -39,29 +39,12 @@
 
     </div>
     <div id="publications">
-
-      <h2>Preprints</h2>
-      <ul>
-        <li>Robi Bhattacharjee, Nick Rittler, and Kamalika Chaudhuri. "<a class="paper-link" href="https://arxiv.org/abs/2405.19156">Beyond Discrepancy: A Closer Look at the Theory of Distribution Shift</a>" In Submission</li>
-      </ul>            
-
       <h2>Publications</h2>
-      <ul>
-	<li>Robi Bhattacharjee and Ulrike von Luxburg. "<a class="paper-link" href="https://arxiv.org/abs/2407.13281">Auditing Local Explanations is Hard.</a>" Neurips 2024
-	<li>Robi Bhattacharjee, Sanjoy Dasgupta, and Kamalika Chaudhuri. "<a class="paper-link" href="https://arxiv.org/abs/2302.13181">Data-Copying in Generative Models: A Formal Framework.</a>" ICML 2023</li>
-        <li>Robi Bhattacharjee, Max Hopkins, Akash Kumar, Hantao Yu, and Kamalika Chaudhuri. "<a class="paper-link" href="https://arxiv.org/abs/2210.00635">Robust Empirical Risk Minimization with Tolerance</a>" ALT 2023</li>	
-        <li>Robi Bhattacharjee, Jacob Imola, Michal Moshkovitz, and Sanjoy Dasgupta. "<a class="paper-link" href="http://arxiv.org/abs/2102.09101">Online k-means Clustering on Arbitrary Data Streams.</a>" ALT 2023</li>	
-	<li>Robi Bhattacharjee and Gaurav Mahajan. "<a class="paper-link" href="https://arxiv.org/abs/2201.03806">Learning what to remember.</a>" ALT 2022 </li>			
-        <li>Robi Bhattacharjee and Kamalika Chaudhuri. "<a class="paper-link" href="http://arxiv.org/abs/2102.09086">Consistent Non-Parametric Methods for Maximizing Robustness.</a>" Neurips 2021 </li>		
-        <li>Robi Bhattacharjeee, Somesh Jha, and Kamalika Chaudhuri. "<a class="paper-link" href="https://arxiv.org/abs/2012.10794">Sample Complexity of Adversarially Robust Linear Classification on Separated Data.</a>" ICML 2021 </li>	
-        <li>Robi Bhattacharjee and Michal Moshkovitz. "<a class="paper-link" href="https://arxiv.org/abs/2012.14512">No-substitution k-means Clustering with Adversarial Order.</a>" ALT 2021.</li>	
-        <li>Robi Bhattacharjee and Kamalika Chaudhuri. "<a class="paper-link" href="https://arxiv.org/abs/2003.06121">When are Non-Parametric Methods Robust?</a>" ICML 2020.</li>
-        <li>Robi Bhattacharjee and Sanjoy Dasgupta. "<a class="paper-link" href="https://arxiv.org/abs/1903.05347">What relations are reliably embeddable in Euclidean space?.</a>" ALT 2020.</li>
-      </ul>
-      <!-- <script src="https://bibbase.org/show?bib=robibhatt.github.io%2FExportedRobiBib.bib&jsonp=1&nocache=1"></script> -->
-
-
-
+      <p>
+        Looking for my research papers? Visit the
+        <a href="publications.html">publications page</a>
+        for a complete list of preprints and published work.
+      </p>
     </div>
     <div id="contact">
       <h2>Contact</h2>

--- a/publications.html
+++ b/publications.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Publications | Robi Bhattacharjee</title>
+  <meta name="description" content="List of publications by Robi Bhattacharjee">
+  <link rel="stylesheet" href="robitemplate.css">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+</head>
+<body>
+  <center>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <a class="navbar-brand" href="index.html">Robi Bhattacharjee</a>
+      <div class="collapse navbar-collapse" id="navbarText">
+        <ul class="navbar-nav">
+          <li class="nav-item">
+            <a class="nav-link" href="index.html#about">About</a>
+          </li>
+          <li class="nav-item active">
+            <a class="nav-link" href="publications.html">Publications</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="index.html#contact">Contact</a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+
+    <div class="publications-list">
+      <h1>Research</h1>
+
+      <section>
+        <h2>Preprints</h2>
+        <ul>
+          <li>Robi Bhattacharjee, Nick Rittler, and Kamalika Chaudhuri. "<a class="paper-link" href="https://arxiv.org/abs/2405.19156">Beyond Discrepancy: A Closer Look at the Theory of Distribution Shift</a>" In Submission</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Publications</h2>
+        <ul>
+          <li>Robi Bhattacharjee and Ulrike von Luxburg. "<a class="paper-link" href="https://arxiv.org/abs/2407.13281">Auditing Local Explanations is Hard.</a>" Neurips 2024</li>
+          <li>Robi Bhattacharjee, Sanjoy Dasgupta, and Kamalika Chaudhuri. "<a class="paper-link" href="https://arxiv.org/abs/2302.13181">Data-Copying in Generative Models: A Formal Framework.</a>" ICML 2023</li>
+          <li>Robi Bhattacharjee, Max Hopkins, Akash Kumar, Hantao Yu, and Kamalika Chaudhuri. "<a class="paper-link" href="https://arxiv.org/abs/2210.00635">Robust Empirical Risk Minimization with Tolerance</a>" ALT 2023</li>
+          <li>Robi Bhattacharjee, Jacob Imola, Michal Moshkovitz, and Sanjoy Dasgupta. "<a class="paper-link" href="http://arxiv.org/abs/2102.09101">Online k-means Clustering on Arbitrary Data Streams.</a>" ALT 2023</li>
+          <li>Robi Bhattacharjee and Gaurav Mahajan. "<a class="paper-link" href="https://arxiv.org/abs/2201.03806">Learning what to remember.</a>" ALT 2022</li>
+          <li>Robi Bhattacharjee and Kamalika Chaudhuri. "<a class="paper-link" href="http://arxiv.org/abs/2102.09086">Consistent Non-Parametric Methods for Maximizing Robustness.</a>" Neurips 2021</li>
+          <li>Robi Bhattacharjeee, Somesh Jha, and Kamalika Chaudhuri. "<a class="paper-link" href="https://arxiv.org/abs/2012.10794">Sample Complexity of Adversarially Robust Linear Classification on Separated Data.</a>" ICML 2021</li>
+          <li>Robi Bhattacharjee and Michal Moshkovitz. "<a class="paper-link" href="https://arxiv.org/abs/2012.14512">No-substitution k-means Clustering with Adversarial Order.</a>" ALT 2021.</li>
+          <li>Robi Bhattacharjee and Kamalika Chaudhuri. "<a class="paper-link" href="https://arxiv.org/abs/2003.06121">When are Non-Parametric Methods Robust?</a>" ICML 2020.</li>
+          <li>Robi Bhattacharjee and Sanjoy Dasgupta. "<a class="paper-link" href="https://arxiv.org/abs/1903.05347">What relations are reliably embeddable in Euclidean space?.</a>" ALT 2020.</li>
+        </ul>
+      </section>
+    </div>
+  </center>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update the home page navigation to link to a dedicated publications page
- add a new publications page that lists preprints and publications previously on the home page

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d7953fa7e48320bf4c908f75f911e7