### PR TITLE
Add jiujitsu page and navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,9 @@
             <li class="nav-item">
               <a class="nav-link" href="#contact">Contact</a>
             </li>
+            <li class="nav-item">
+              <a class="nav-link" href="jiujitsu.html">Jiujitsu</a>
+            </li>
           </ul>
         </div>
     </nav>

--- a/jiujitsu.html
+++ b/jiujitsu.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Jiujitsu | Robi Bhattacharjee</title>
+  <meta name="description" content="Jiujitsu adventures of Robi Bhattacharjee">
+  <link rel="stylesheet" href="robitemplate.css">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+</head>
+<body>
+  <center>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <a class="navbar-brand" href="index.html">Robi Bhattacharjee</a>
+      <div class="collapse navbar-collapse" id="navbarText">
+        <ul class="navbar-nav">
+          <li class="nav-item">
+            <a class="nav-link" href="index.html#about">About</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="publications.html">Publications</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="index.html#contact">Contact</a>
+          </li>
+          <li class="nav-item active">
+            <a class="nav-link" href="jiujitsu.html">Jiujitsu</a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+
+    <div class="jiujitsu-message">
+      <h1>He can do jiu jitsu magical superstar</h1>
+    </div>
+  </center>
+</body>
+</html>

--- a/publications.html
+++ b/publications.html
@@ -23,6 +23,9 @@
           <li class="nav-item">
             <a class="nav-link" href="index.html#contact">Contact</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="jiujitsu.html">Jiujitsu</a>
+          </li>
         </ul>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- add a jiujitsu navigation link to the homepage and publications page headers
- create a jiujitsu page with consistent navigation and the requested message

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d79f90291083209e3e4b111cb29263