### PR TITLE
Rework index layout with two-column intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,8 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 </head>
 <body>
-  <center>
-
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <div class="container py-4">
+    <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
         <a class="navbar-brand" href="#">Robi Bhattacharjee</a>
         <div class="collapse navbar-collapse" id="navbarText">
           <ul class="navbar-nav">
@@ -35,32 +34,34 @@
         </div>
     </nav>
 
-  <br>
-    <img src="robi_headshot.jpeg"/>
-    <br>
-    <div id="about">
-      <p>
-        I'm currently a chubbybubble at the Univeristy of Tubingen supervised by Ulrike von Luxburg. Previously, I completed my Phd at UC San Diego where I was fortunate to be co-advised by Kamalika Chaudhuri and Sanjoy Dasgupta. I'm broadly interested in various theoretical topics that fall under the umbrella of Trustworthy Machine Learning. Recently, I've been interested in studying basic problems in explainability. I've previously worked in adversarial robustness as well as online k-means clustering. I also like math, in which I receieved a B.S. from MIT in 2016. 
-      </p>
-
+    <div class="index-layout">
+      <div class="index-image-column">
+        <img src="robi_headshot.jpeg" alt="Robi Bhattacharjee" class="index-image" />
+      </div>
+      <div class="index-content-column">
+        <div id="about" class="mb-4">
+          <p>
+            I'm currently a chubbybubble at the Univeristy of Tubingen supervised by Ulrike von Luxburg. Previously, I completed my Phd at UC San Diego where I was fortunate to be co-advised by Kamalika Chaudhuri and Sanjoy Dasgupta. I'm broadly interested in various theoretical topics that fall under the umbrella of Trustworthy Machine Learning. Recently, I've been interested in studying basic problems in explainability. I've previously worked in adversarial robustness as well as online k-means clustering. I also like math, in which I receieved a B.S. from MIT in 2016.
+          </p>
+        </div>
+        <div id="publications" class="mb-4">
+          <h2>Publications</h2>
+          <p>
+            Looking for my research papers? Visit the
+            <a href="publications.html">publications page</a>
+            for a complete list of preprints and published work.
+          </p>
+        </div>
+        <div id="contact" class="mb-4">
+          <h2>Contact</h2>
+          Email: rcbhatta at eng.ucsd.edu <br>
+          <a href="https://scholar.google.com/citations?user=zB23BxYAAAAJ&hl=en">Google Scholar</a> <br>
+          <a href="cv.pdf">CV</a>
+        </div>
+      </div>
     </div>
-    <div id="publications">
-      <h2>Publications</h2>
-      <p>
-        Looking for my research papers? Visit the
-        <a href="publications.html">publications page</a>
-        for a complete list of preprints and published work.
-      </p>
-    </div>
-    <div id="contact">
-      <h2>Contact</h2>
-      Email: rcbhatta at eng.ucsd.edu <br>
-      <a href="https://scholar.google.com/citations?user=zB23BxYAAAAJ&hl=en">Google Scholar</a> <br>
-      <a href="cv.pdf">CV</a>      
-    </div>
-    <div id="scroll-padding">
-    </div>
-  </center>
+    <div id="scroll-padding"></div>
+  </div>
 
 </body>
 

--- a/robitemplate.css
+++ b/robitemplate.css
@@ -1,34 +1,4 @@
 body {
-  font-size: 2rem !important;
-}
-
-ul {
-  text-align: left;
-  display: inline-block;
-}
-
-img {
-  max-width: 500px;
-  width: 90%;
-  padding-bottom: 1rem;
-}
-
-.navbar-brand {
-  font-size: 1.3em !important;
-  color: #454545 !important;
-}
-
-.paper-link {
-  color: black;
-  font-weight: bold;
-}
-
-#about {
-  max-width: 800px;
-  width: 90%;
-  text-align: left;
-  display: inline-block;
-}body {
   font-size: 1.2rem !important;
 }
 
@@ -45,25 +15,60 @@ img {
 
 .navbar-brand {
   font-size: 1.5rem !important;
+  color: #454545 !important;
 }
 
-#about {
-  max-width: 800px;
-  width: 90%;
-  text-align: left;
-  display: inline-block;
+.paper-link {
+  color: black;
+  font-weight: bold;
 }
 
-#publications {
-  max-width: 800px;
-  width: 90%;
-}
-
+#about,
+#publications,
 #contact {
   max-width: 800px;
-  width: 90%;
+  width: 100%;
+  text-align: left;
+  display: block;
 }
 
 #scroll-padding {
   height: 95vh;
+}
+
+.index-layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+.index-image-column {
+  flex: 0 0 35%;
+  max-width: 35%;
+  display: flex;
+  justify-content: center;
+}
+
+.index-content-column {
+  flex: 1 1 0;
+  max-width: 100%;
+}
+
+.index-image {
+  width: 100%;
+  max-width: none;
+  padding-bottom: 0;
+}
+
+@media (max-width: 767.98px) {
+  .index-image-column,
+  .index-content-column {
+    flex: 1 1 100%;
+    max-width: 100%;
+  }
+
+  .index-image {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- restructure the index page so the headshot sits in its own left column with the text content aligned alongside it
- update shared styles to size the index photo to 35% of the page width and support responsive stacking on smaller screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7ddb11b6c83208158359c602c6877