### PR TITLE
Use Playfair Display as sitewide font

### DIFF
--- a/home.html
+++ b/home.html
@@ -17,7 +17,7 @@
 
     body {
       margin: 0;
-      font-family: "Helvetica Neue", Arial, sans-serif;
+      font-family: "Playfair Display", serif;
       line-height: 1.6;
       color: #222;
       background-color: #f9f9f9;

--- a/robitemplate.css
+++ b/robitemplate.css
@@ -1,4 +1,7 @@
+@import url("https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600;700&display=swap");
+
 body {
+  font-family: "Playfair Display", serif;
   font-size: 1.2rem !important;
 }
 


### PR DESCRIPTION
## Summary
- import the Playfair Display typeface and apply it as the global font across the site
- update the home page's inline styles to inherit the new serif typeface

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f012a2c883208c93bf733ca8bd26