### PR TITLE
Align carousel with main content column

### DIFF
--- a/home.html
+++ b/home.html
@@ -47,11 +47,12 @@
       border-radius: 12px;
       box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
       background: transparent;
-      width: 100vw;
+      width: 100%;
+      max-width: 960px;
       height: 45vh;
       min-height: 260px;
-      margin: 0 calc(50% - 50vw) 2.5rem;
-      padding: 0.75rem 0;
+      margin: 0 auto 2.5rem;
+      padding: 0.75rem 1rem;
     }
 
     .carousel__track {


### PR DESCRIPTION
## Summary
- constrain the home page carousel to the main column width and center it with standard margins
- add horizontal padding so the carousel follows the same gutters as the rest of the content

## Testing
- python3 -m http.server 8000 (with Playwright visual checks at 1280px, 768px, and 480px viewports)


------
https://chatgpt.com/codex/tasks/task_e_68d7fad6e3f883208f3bb7d9605c5cbd