### PR TITLE
Add research section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,36 @@
           I'm currently a chubbybubble at the Univeristy of Tubingen supervised by Ulrike von Luxburg. Previously, I completed my Phd at UC San Diego where I was fortunate to be co-advised by Kamalika Chaudhuri and Sanjoy Dasgupta. I'm broadly interested in various theoretical topics that fall under the umbrella of Trustworthy Machine Learning. Recently, I've been interested in studying basic problems in explainability. I've previously worked in adversarial robustness as well as online k-means clustering. I also like math, in which I receieved a B.S. from MIT in 2016.
         </p>
       </div>
+      <div id="research" class="mb-4">
+        <h2>Research</h2>
+        <div class="mb-3">
+          <h3>Explainability</h3>
+          <p>
+            A bit about this area of my research--<br>
+            Paper 1<br>
+            Paper 2<br>
+            Paper 3
+          </p>
+        </div>
+        <div class="mb-3">
+          <h3>K-NN</h3>
+          <p>
+            A bit about this area of my research--<br>
+            Paper 1<br>
+            Paper 2<br>
+            Paper 3
+          </p>
+        </div>
+        <div class="mb-3">
+          <h3>Online Clustering</h3>
+          <p>
+            A bit about this area of my research--<br>
+            Paper 1<br>
+            Paper 2<br>
+            Paper 3
+          </p>
+        </div>
+      </div>
       <div id="publications" class="mb-4">
         <h2>Publications</h2>
         <p>


### PR DESCRIPTION
## Summary
- add a research section on the homepage above the publications content
- outline three focus areas with placeholder paper listings under each subheading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7fd3f5fbc83209aeaa39dcda33580