### PR TITLE
Add Font Awesome list styling to Explainability section

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <meta property="og:description" content="Robi Bhattacharjee's personal website" />
   <meta property="og:site_name" content="Robi Bhattacharjee" />
   <link rel="stylesheet" href="robitemplate.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 </head>
 <body class="playfair-font">
@@ -48,14 +49,25 @@
         <div class="mb-3">
           <h3>Explainability</h3>
           <p>
-            A bit about this area of my research--<br>
-            <a href="https://arxiv.org/abs/2508.11441">Informative Post-Hoc Explanations Only Exist for Simple Functions</a><br>
-            E Günther, B Szabados, <strong>R Bhattacharjee</strong>, S Bordt, U von Luxburg<br>
-            <a href="https://arxiv.org/abs/2503.23111">How to safely discard features based on aggregate SHAP values</a><br>
-            <strong>R Bhattacharjee</strong>, K Frohnapfel, U von Luxburg<br>
-            <a href="https://scholar.google.com/citations?view_op=view_citation&amp;hl=en&amp;user=zB23BxYAAAAJ&amp;sortby=pubdate&amp;citation_for_view=zB23BxYAAAAJ%3A0EnyYjriUFMC&amp;inst=3203679203499159833">Auditing local explanations is hard</a><br>
-            R Bhattacharjee, U Luxburg
+            A bit about this area of my research--
           </p>
+          <ul class="fa-ul">
+            <li>
+              <span class="fa-li"><i class="fa-solid fa-magnifying-glass"></i></span>
+              <a href="https://arxiv.org/abs/2508.11441">Informative Post-Hoc Explanations Only Exist for Simple Functions</a><br>
+              E Günther, B Szabados, <strong>R Bhattacharjee</strong>, S Bordt, U von Luxburg
+            </li>
+            <li>
+              <span class="fa-li"><i class="fa-solid fa-magnifying-glass"></i></span>
+              <a href="https://arxiv.org/abs/2503.23111">How to safely discard features based on aggregate SHAP values</a><br>
+              <strong>R Bhattacharjee</strong>, K Frohnapfel, U von Luxburg
+            </li>
+            <li>
+              <span class="fa-li"><i class="fa-solid fa-magnifying-glass"></i></span>
+              <a href="https://scholar.google.com/citations?view_op=view_citation&amp;hl=en&amp;user=zB23BxYAAAAJ&amp;sortby=pubdate&amp;citation_for_view=zB23BxYAAAAJ%3A0EnyYjriUFMC&amp;inst=3203679203499159833">Auditing local explanations is hard</a><br>
+              R Bhattacharjee, U Luxburg
+            </li>
+          </ul>
         </div>
         <div class="mb-3">
           <h3>K-NN</h3>


### PR DESCRIPTION
## Summary
- add Font Awesome CDN stylesheet so icons can be used on the site
- convert the Explainability research items into a Font Awesome bulleted list with magnifying glass icons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d807ce84dc8320a4552b58a3d6d131