### PR TITLE
Center section headings and open explainability links in new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,17 +54,17 @@
           <ul class="fa-ul">
             <li>
               <span class="fa-li"><i class="fa-solid fa-magnifying-glass"></i></span>
-              <a href="https://arxiv.org/abs/2508.11441">Informative Post-Hoc Explanations Only Exist for Simple Functions</a><br>
+              <a href="https://arxiv.org/abs/2508.11441" target="_blank" rel="noopener noreferrer">Informative Post-Hoc Explanations Only Exist for Simple Functions</a><br>
               E Günther, B Szabados, <strong>R Bhattacharjee</strong>, S Bordt, U von Luxburg
             </li>
             <li>
               <span class="fa-li"><i class="fa-solid fa-magnifying-glass"></i></span>
-              <a href="https://arxiv.org/abs/2503.23111">How to safely discard features based on aggregate SHAP values</a><br>
+              <a href="https://arxiv.org/abs/2503.23111" target="_blank" rel="noopener noreferrer">How to safely discard features based on aggregate SHAP values</a><br>
               <strong>R Bhattacharjee</strong>, K Frohnapfel, U von Luxburg
             </li>
             <li>
               <span class="fa-li"><i class="fa-solid fa-magnifying-glass"></i></span>
-              <a href="https://scholar.google.com/citations?view_op=view_citation&amp;hl=en&amp;user=zB23BxYAAAAJ&amp;sortby=pubdate&amp;citation_for_view=zB23BxYAAAAJ%3A0EnyYjriUFMC&amp;inst=3203679203499159833">Auditing local explanations is hard</a><br>
+              <a href="https://scholar.google.com/citations?view_op=view_citation&amp;hl=en&amp;user=zB23BxYAAAAJ&amp;sortby=pubdate&amp;citation_for_view=zB23BxYAAAAJ%3A0EnyYjriUFMC&amp;inst=3203679203499159833" target="_blank" rel="noopener noreferrer">Auditing local explanations is hard</a><br>
               R Bhattacharjee, U Luxburg
             </li>
           </ul>

--- a/robitemplate.css
+++ b/robitemplate.css
@@ -40,6 +40,12 @@ img {
   display: block;
 }
 
+#research h2,
+#publications h2,
+#contact h2 {
+  text-align: center;
+}
+
 #scroll-padding {
   height: 95vh;
 }


### PR DESCRIPTION
## Summary
- center the Research, Publications, and Contact section headings within the main column
- open the Explainability research links in a new tab for easier navigation

## Testing
- not run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68d80c1b33708320a8bf0d9415c4f013