### PR TITLE
Rename home page to about and center title

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Home - Robi Bhattacharjee</title>
+  <title>About - Robi Bhattacharjee</title>
   <link rel="stylesheet" href="robitemplate.css">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
   <style>
@@ -37,6 +37,10 @@
       width: 100%;
       margin: 0 auto;
       padding: 0 1rem;
+    }
+
+    .content > h1 {
+      text-align: center;
     }
 
     .carousel {
@@ -195,8 +199,8 @@
       <a class="navbar-brand" href="index.html">Robi Bhattacharjee</a>
       <div class="collapse navbar-collapse" id="navbarText">
         <ul class="navbar-nav">
-          <li class="nav-item">
-            <a class="nav-link" href="home.html">Home</a>
+          <li class="nav-item active">
+            <a class="nav-link" href="about.html">About</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="publications.html">Publications</a>
@@ -212,6 +216,9 @@
     </nav>
   </header>
   <main>
+    <div class="content">
+      <h1>The Fun Stuff</h1>
+    </div>
     <section class="carousel" aria-label="Featured moments of Robi Bhattacharjee">
       <div class="carousel__track" role="list">
         <article class="carousel__slide" role="listitem">

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
       <div class="collapse navbar-collapse" id="navbarText">
         <ul class="navbar-nav">
           <li class="nav-item">
-            <a class="nav-link" href="home.html">Home</a>
+            <a class="nav-link" href="about.html">About</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="publications.html">Publications</a>

--- a/jiujitsu.html
+++ b/jiujitsu.html
@@ -15,7 +15,7 @@
       <div class="collapse navbar-collapse" id="navbarText">
         <ul class="navbar-nav">
           <li class="nav-item">
-            <a class="nav-link" href="index.html#about">About</a>
+            <a class="nav-link" href="about.html">About</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="publications.html">Publications</a>

--- a/publications.html
+++ b/publications.html
@@ -15,7 +15,7 @@
       <div class="collapse navbar-collapse" id="navbarText">
         <ul class="navbar-nav">
           <li class="nav-item">
-            <a class="nav-link" href="index.html#about">About</a>
+            <a class="nav-link" href="about.html">About</a>
           </li>
           <li class="nav-item active">
             <a class="nav-link" href="publications.html">Publications</a>


### PR DESCRIPTION
## Summary
- rename the former home page to about.html and update its browser title
- update navigation links across pages to use the About label and new URL
- add an on-page heading for the About section so the page shows "The Fun Stuff"
- center the About page heading beneath the site header

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d81017601083209873fff633c68f72