### PR TITLE
Update research listings on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,18 +80,27 @@
           <ul class="fa-ul">
             <li>
               <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              Beyond Discrepancy: A Closer Look at the Theory of Distribution Shift<br>
-              R Bhattacharjee, N Rittler, K Chaudhuri
+              <a href="https://arxiv.org/abs/2210.00635" target="_blank" rel="noopener noreferrer">Robust Empirical Risk Minimization with Tolerance</a><br>
+              <strong>R Bhattacharjee</strong>, M Hopkins, A Kumar, H Yu, K Chaudhuri<br>
+              ALT 2023
             </li>
             <li>
               <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              Data-copying in generative models: a formal framework<br>
-              R Bhattacharjee, S Dasgupta, K Chaudhuri
+              <a href="https://arxiv.org/abs/2102.09086" target="_blank" rel="noopener noreferrer">Consistent Non-Parametric Methods for Maximizing Robustness</a><br>
+              <strong>R Bhattacharjee</strong>, K Chaudhuri<br>
+              Neurips 2021
             </li>
             <li>
               <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              Effective resistance in metric spaces<br>
-              R Bhattacharjee, A Cloninger, Y Freund, A Oslandsbotn
+              <a href="https://arxiv.org/abs/2012.10794" target="_blank" rel="noopener noreferrer">Sample Complexity of Adversarially Robust Linear Classification on Separated Data</a><br>
+              <strong>R Bhattacharjee</strong>, S Jha, K Chaudhuri<br>
+              ICML 2021
+            </li>
+            <li>
+              <span class="fa-li"><i class="fa-solid fa-link"></i></span>
+              <a href="https://arxiv.org/abs/2003.06121" target="_blank" rel="noopener noreferrer">When are Non-Parametric Methods Robust?</a><br>
+              <strong>R Bhattacharjee</strong>, K Chaudhuri<br>
+              ICML 2020
             </li>
           </ul>
         </div>
@@ -101,18 +110,21 @@
           <ul class="fa-ul">
             <li>
               <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              Online k-means clustering on arbitrary data streams<br>
-              R Bhattacharjee, J Imola, M Moshkovitz, S Dasgupta
+              <a href="https://arxiv.org/abs/2102.09101" target="_blank" rel="noopener noreferrer">Online k-means Clustering on Arbitrary Data Streams</a><br>
+              <strong>R Bhattacharjee</strong>, J Imola, M Moshkovitz, S Dasgupta<br>
+              ALT 2023
             </li>
             <li>
               <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              Data-copying in generative models: a formal framework<br>
-              R Bhattacharjee, S Dasgupta, K Chaudhuri
+              <a href="https://arxiv.org/abs/2201.03806" target="_blank" rel="noopener noreferrer">Learning what to remember</a><br>
+              <strong>R Bhattacharjee</strong>, G Mahajan<br>
+              ALT 2022
             </li>
             <li>
               <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              No-substitution k-means clustering with adversarial order<br>
-              R Bhattacharjee, M Moshkovitz
+              <a href="https://arxiv.org/abs/2012.14512" target="_blank" rel="noopener noreferrer">No-substitution k-means Clustering with Adversarial Order</a><br>
+              <strong>R Bhattacharjee</strong>, M Moshkovitz<br>
+              ALT 2021
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- replace the Adversarial Robustness entries on the home page with the latest linked publications and venues
- refresh the Online Learning list with updated publication links and bolded author formatting

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8238c012083208cb9ee81aa2b2190