### PR TITLE
Move contact section under headshot on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,12 @@
   <div class="index-layout">
     <div class="index-image-column">
       <img src="robi_headshot.jpeg" alt="Robi Bhattacharjee" class="index-image" />
+      <div id="contact" class="mb-4">
+        <h2>Contact</h2>
+        Email: rcbhatta at eng.ucsd.edu <br>
+        <a href="https://scholar.google.com/citations?user=zB23BxYAAAAJ&hl=en">Google Scholar</a> <br>
+        <a href="cv.pdf">CV</a>
+      </div>
     </div>
     <div class="index-content-column">
       <div id="about" class="mb-4">
@@ -136,12 +142,6 @@
           <a href="publications.html">publications page</a>
           for a complete list of preprints and published work.
         </p>
-      </div>
-      <div id="contact" class="mb-4">
-        <h2>Contact</h2>
-        Email: rcbhatta at eng.ucsd.edu <br>
-        <a href="https://scholar.google.com/citations?user=zB23BxYAAAAJ&hl=en">Google Scholar</a> <br>
-        <a href="cv.pdf">CV</a>
       </div>
     </div>
   </div>

--- a/robitemplate.css
+++ b/robitemplate.css
@@ -55,13 +55,22 @@ img {
   flex-wrap: wrap;
   gap: 2rem;
   align-items: flex-start;
+  max-width: 960px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 3rem;
 }
 
 .index-image-column {
   flex: 0 0 35%;
   max-width: 35%;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+}
+
+.index-image-column #contact {
+  margin-top: 2rem;
 }
 
 .index-content-column {


### PR DESCRIPTION
## Summary
- move the homepage contact section into the left column so it appears below the headshot image
- update the left column layout to stack its contents vertically and center them
- add homepage padding to match the About page margins and create extra space between the headshot and Contact heading

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d82544ce7483208b12d82ba441104b