### PR TITLE
Update publication page icon and spacing

### DIFF
--- a/publications.html
+++ b/publications.html
@@ -34,7 +34,6 @@
     <h1 class="page-title">Publications</h1>
 
     <section class="publications-section">
-      <h2>Published &amp; Accepted Papers</h2>
       <ol class="publications-list" reversed start="12">
         <li>
           <div class="publication-row">

--- a/robitemplate.css
+++ b/robitemplate.css
@@ -115,7 +115,7 @@ img {
 }
 
 .publications-list li {
-  margin-bottom: 1.75rem;
+  margin-bottom: 1rem;
 }
 
 .publication-row {
@@ -147,7 +147,7 @@ img {
 
 .publication-authors .fa-li {
   left: -1.75rem;
-  color: #666;
+  color: #4da3ff;
 }
 
 .publication-right {


### PR DESCRIPTION
## Summary
- lighten the author icon on the publications page to a visible light blue and reduce spacing between entries
- remove the "Published & Accepted Papers" subtitle from the publications page

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d83eda85588320a9bed77f5cce44ec