### PR TITLE
Align publication layout columns

### DIFF
--- a/robitemplate.css
+++ b/robitemplate.css
@@ -110,8 +110,13 @@ img {
 
 .publications-list {
   display: block;
-  padding-left: 1.75rem;
+  padding-left: 2.5rem;
   margin: 0;
+  list-style-position: outside;
+}
+
+.publications-list li::marker {
+  font-variant-numeric: tabular-nums;
 }
 
 .publications-list li {
@@ -120,7 +125,7 @@ img {
 
 .publication-row {
   display: grid;
-  grid-template-columns: minmax(0, 3fr) minmax(0, 1.25fr);
+  grid-template-columns: minmax(0, 1fr) minmax(8rem, auto);
   gap: 1.5rem;
   align-items: start;
 }
@@ -151,7 +156,8 @@ img {
 }
 
 .publication-right {
-  text-align: right;
+  text-align: left;
+  justify-self: start;
   font-size: 1rem;
   color: #333;
 }
@@ -173,13 +179,14 @@ img {
 
 .preprint-content {
   display: grid;
-  grid-template-columns: minmax(0, 3fr) minmax(0, 1.25fr);
+  grid-template-columns: minmax(0, 1fr) minmax(8rem, auto);
   gap: 1.5rem;
   align-items: start;
 }
 
 .preprint-right {
-  text-align: right;
+  text-align: left;
+  justify-self: start;
   color: #333;
 }
 


### PR DESCRIPTION
## Summary
- left-align the publication and preprint metadata columns to keep entries in-line
- adjust ordered list spacing and markers so publication numbers and titles align cleanly

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8487c4f68832082d8bd6ed4800c47