### PR TITLE
Add dedicated CV page and navigation link

### DIFF
--- a/about.html
+++ b/about.html
@@ -201,6 +201,9 @@
             <a class="nav-link" href="publications.html">Publications</a>
           </li>
           <li class="nav-item">
+            <a class="nav-link" href="cv.html">CV</a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link" href="#contact">Contact</a>
           </li>
           <li class="nav-item">

--- a/cv.html
+++ b/cv.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CV | Robi Bhattacharjee</title>
+  <meta name="description" content="Curriculum Vitae of Robi Bhattacharjee">
+  <link rel="stylesheet" href="robitemplate.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOCQHj4Xq+1Q0tRzUGmu0FK7mwH6v+t3R7u1ieqxCfXWYnf4XWUTyvgrc1jFZh/TmZbR7ZDT+xYpP4hZH6+g==" crossorigin="anonymous" referrerpolicy="no-referrer">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+</head>
+<body class="playfair-font">
+  <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+    <a class="navbar-brand" href="index.html">Robi Bhattacharjee</a>
+    <div class="collapse navbar-collapse" id="navbarText">
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a class="nav-link" href="about.html">About</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="publications.html">Publications</a>
+        </li>
+        <li class="nav-item active">
+          <a class="nav-link" href="cv.html">CV</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="index.html#contact">Contact</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="jiujitsu.html">Jiujitsu</a>
+        </li>
+      </ul>
+    </div>
+  </nav>
+
+  <main class="page-container cv-page">
+    <header class="cv-header">
+      <h1 class="cv-name">Robi Bhattacharjee</h1>
+      <div class="cv-meta">
+        <div>
+          <p>28 Quenstedtstrasse<br>Tübingen 72076, Germany</p>
+        </div>
+        <div>
+          <p><strong>Contact</strong><br>
+            <a href="mailto:robibhatt@gmail.com">robibhatt@gmail.com</a><br>
+            <a href="https://robibhatt.github.io">robibhatt.github.io</a><br>
+            <a href="https://github.com/robibhatt">github.com/robibhatt</a>
+          </p>
+        </div>
+      </div>
+    </header>
+
+    <section class="cv-section">
+      <h2>Education</h2>
+      <div class="cv-entry">
+        <div class="cv-entry-header">
+          <div>
+            <h3 class="cv-entry-title">University of California, San Diego</h3>
+            <p class="cv-entry-role">PhD in Computer Science</p>
+          </div>
+          <div class="cv-entry-meta">Fall 2018 &ndash; July 2023</div>
+        </div>
+        <p class="cv-entry-description">Advised by Kamalika Chaudhuri and Sanjoy Dasgupta.</p>
+      </div>
+      <div class="cv-entry">
+        <div class="cv-entry-header">
+          <div>
+            <h3 class="cv-entry-title">Massachusetts Institute of Technology</h3>
+            <p class="cv-entry-role">Bachelor of Science, General Mathematics</p>
+          </div>
+          <div class="cv-entry-meta">June 2016</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="cv-section">
+      <h2>Work Experience</h2>
+      <div class="cv-entry">
+        <div class="cv-entry-header">
+          <div>
+            <h3 class="cv-entry-title">Postdoctoral Researcher</h3>
+            <p class="cv-entry-role">University of Tübingen &mdash; Tübingen, Germany</p>
+          </div>
+          <div class="cv-entry-meta">Oct 2023 &ndash; Present</div>
+        </div>
+        <p class="cv-entry-description">Supervised by Ulrike von Luxburg. Conducting research in theoretical machine learning.</p>
+      </div>
+      <div class="cv-entry">
+        <div class="cv-entry-header">
+          <div>
+            <h3 class="cv-entry-title">PhD Student, Graduate Research Assistant</h3>
+            <p class="cv-entry-role">UC San Diego &mdash; San Diego, CA</p>
+          </div>
+          <div class="cv-entry-meta">Fall 2018 &ndash; July 2023</div>
+        </div>
+        <p class="cv-entry-description">Conducted research in adversarial robustness, clustering, and trustworthy machine learning under Kamalika Chaudhuri and Sanjoy Dasgupta.</p>
+      </div>
+      <div class="cv-entry">
+        <div class="cv-entry-header">
+          <div>
+            <h3 class="cv-entry-title">Assistant Trader</h3>
+            <p class="cv-entry-role">Five Rings Capital &mdash; New York, NY</p>
+          </div>
+          <div class="cv-entry-meta">June 2016 &ndash; July 2017</div>
+        </div>
+        <p class="cv-entry-description">Developed automated trading strategies and coded simulations on historical market data.</p>
+      </div>
+      <div class="cv-entry">
+        <div class="cv-entry-header">
+          <div>
+            <h3 class="cv-entry-title">Research Intern</h3>
+            <p class="cv-entry-role">Jane Street Capital &mdash; New York, NY</p>
+          </div>
+          <div class="cv-entry-meta">Summer 2015</div>
+        </div>
+        <p class="cv-entry-description">Worked on trading strategies and statistical tools for improving them.</p>
+      </div>
+      <div class="cv-entry">
+        <div class="cv-entry-header">
+          <div>
+            <h3 class="cv-entry-title">Software Engineering Intern</h3>
+            <p class="cv-entry-role">Google &mdash; Mountain View, CA</p>
+          </div>
+          <div class="cv-entry-meta">Summer 2014</div>
+        </div>
+        <p class="cv-entry-description">Studied the effect of over- and under-sampling to resolve class imbalance for fraud detection.</p>
+      </div>
+      <div class="cv-entry">
+        <div class="cv-entry-header">
+          <div>
+            <h3 class="cv-entry-title">Trading/Research Intern</h3>
+            <p class="cv-entry-role">Jane Street Capital &mdash; New York, NY</p>
+          </div>
+          <div class="cv-entry-meta">Summer 2013</div>
+        </div>
+        <p class="cv-entry-description">Worked on trading strategies and participated in mock trading exercises.</p>
+      </div>
+    </section>
+
+    <section class="cv-section">
+      <h2>Teaching</h2>
+      <div class="cv-entry">
+        <div class="cv-entry-header">
+          <div>
+            <h3 class="cv-entry-title">Teaching Assistant, CSE 251B (Graduate Machine Learning)</h3>
+            <p class="cv-entry-role">UC San Diego</p>
+          </div>
+          <div class="cv-entry-meta">Winter 2022</div>
+        </div>
+        <p class="cv-entry-description">Led discussion sections, held office hours, graded assignments and exams.</p>
+      </div>
+      <div class="cv-entry">
+        <div class="cv-entry-header">
+          <div>
+            <h3 class="cv-entry-title">Teaching Assistant, CSE 251B (Graduate Machine Learning)</h3>
+            <p class="cv-entry-role">UC San Diego</p>
+          </div>
+          <div class="cv-entry-meta">Winter 2021</div>
+        </div>
+        <p class="cv-entry-description">Led discussion sections, held office hours, graded assignments and exams.</p>
+      </div>
+      <div class="cv-entry">
+        <div class="cv-entry-header">
+          <div>
+            <h3 class="cv-entry-title">Teaching Assistant, Seminar &ldquo;Explainable Machine Learning&rdquo;</h3>
+            <p class="cv-entry-role">University of Tübingen</p>
+          </div>
+          <div class="cv-entry-meta">Summer 2024</div>
+        </div>
+        <p class="cv-entry-description">Co-led by Ulrike von Luxburg and Robi Bhattacharjee. Delivered lectures (e.g. on LIME/SHAP), guided student presentations, and organized the seminar schedule.</p>
+      </div>
+    </section>
+
+    <section class="cv-section">
+      <h2>Supervision</h2>
+      <div class="cv-entry">
+        <div class="cv-entry-header">
+          <div>
+            <h3 class="cv-entry-title">Clara Groethans</h3>
+            <p class="cv-entry-role">Master&rsquo;s Student, University of Tübingen</p>
+          </div>
+          <div class="cv-entry-meta">Oct 2024 &ndash; Jun 2025</div>
+        </div>
+        <p class="cv-entry-description">Thesis: <em>Understanding the Interplay between Model Complexity and Explanation Quality: Measuring Local Fidelity</em>.</p>
+      </div>
+      <div class="cv-entry">
+        <div class="cv-entry-header">
+          <div>
+            <h3 class="cv-entry-title">Harald Kugler</h3>
+            <p class="cv-entry-role">Master&rsquo;s Student, University of Tübingen</p>
+          </div>
+          <div class="cv-entry-meta">Apr 2024 &ndash; Oct 2024</div>
+        </div>
+        <p class="cv-entry-description">Thesis: <em>Towards a Reliable and Scalable Data-Copying Detection Algorithm Using Random Projections</em>.</p>
+      </div>
+    </section>
+
+    <section class="cv-section">
+      <h2>Publications</h2>
+      <ul class="cv-list">
+        <li>Robi Bhattacharjee, Geelon So, and Sanjoy Dasgupta. &ldquo;Consistency of the k<sub>n</sub>-nearest neighbor rule under adaptive sampling.&rdquo; NeurIPS 2025.</li>
+        <li>Robi Bhattacharjee, Karolin Frohnapfel, and Ulrike von Luxburg. &ldquo;How to Safely Discard Features Based on Aggregate SHAP Values.&rdquo; COLT 2025.</li>
+        <li>Robi Bhattacharjee and Ulrike von Luxburg. &ldquo;Auditing Local Explanations is Hard.&rdquo; NeurIPS 2024.</li>
+        <li>Robi Bhattacharjee, Sanjoy Dasgupta, and Kamalika Chaudhuri. &ldquo;Data-Copying in Generative Models: A Formal Framework.&rdquo; ICML 2023.</li>
+        <li>Robi Bhattacharjee, Max Hopkins, Akash Kumar, Hantao Yu, and Kamalika Chaudhuri. &ldquo;Robust Empirical Risk Minimization with Tolerance.&rdquo; ALT 2023.</li>
+        <li>Robi Bhattacharjee, Jacob Imola, Michal Moshkovitz, and Sanjoy Dasgupta. &ldquo;Online k-means Clustering on Arbitrary Data Streams.&rdquo; ALT 2023.</li>
+        <li>Robi Bhattacharjee and Gaurav Mahajan. &ldquo;Learning What to Remember.&rdquo; ALT 2022.</li>
+        <li>Robi Bhattacharjee and Kamalika Chaudhuri. &ldquo;Consistent Non-Parametric Methods for Maximizing Robustness.&rdquo; NeurIPS 2021.</li>
+        <li>Robi Bhattacharjee, Somesh Jha, and Kamalika Chaudhuri. &ldquo;Sample Complexity of Adversarially Robust Linear Classification on Separated Data.&rdquo; ICML 2021.</li>
+        <li>Robi Bhattacharjee and Michal Moshkovitz. &ldquo;No-substitution k-means Clustering with Adversarial Order.&rdquo; ALT 2021.</li>
+        <li>Robi Bhattacharjee and Kamalika Chaudhuri. &ldquo;When are Non-Parametric Methods Robust?&rdquo; ICML 2020.</li>
+        <li>Robi Bhattacharjee and Sanjoy Dasgupta. &ldquo;What Relations are Reliably Embeddable in Euclidean Space?&rdquo; ALT 2020.</li>
+      </ul>
+    </section>
+
+    <section class="cv-section">
+      <h2>Preprints / In Submission</h2>
+      <ul class="cv-list">
+        <li>Eric Günther, Balázs Szabados, Robi Bhattacharjee, Sebastian Bordt, and Ulrike von Luxburg. &ldquo;Informative Post-Hoc Explanations Only Exist for Simple Functions.&rdquo; arXiv preprint, 2025.</li>
+        <li>Robi Bhattacharjee, Nick Rittler, and Kamalika Chaudhuri. &ldquo;Beyond Discrepancy: A Closer Look at the Theory of Distribution Shift.&rdquo; In submission.</li>
+      </ul>
+    </section>
+
+    <section class="cv-section">
+      <h2>Service</h2>
+      <ul class="cv-list">
+        <li>Mentor for UCSD Graduate Women in Computing (Fall 2020 &ndash; Winter 2021).</li>
+        <li>Geometry teacher for MISE foundation (Winter &ndash; Summer 2021).</li>
+        <li>Reviewer for AISTATS (Fall 2020).</li>
+        <li>Reviewer for JMLR (Winter 2021).</li>
+      </ul>
+    </section>
+
+    <section class="cv-section">
+      <h2>Reviewing</h2>
+      <ul class="cv-list">
+        <li>Reviewer, NeurIPS (2025, 2024, 2023).</li>
+        <li>Reviewer, ICML (2025, 2024, 2022, 2021).</li>
+        <li>Reviewer, ICLR (2025).</li>
+        <li>Reviewer, ALT (2025).</li>
+      </ul>
+    </section>
+
+    <section class="cv-section">
+      <h2>Honors and Awards</h2>
+      <ul class="cv-list">
+        <li>Honorable Mention on the William Lowell Putnam Examination (2012, 2013).</li>
+        <li>9th place individual nationally in the American Regional Mathematics Competition.</li>
+        <li>Participant of the Math Olympiad Summer Program (2010).</li>
+        <li>USAMO qualifier 2009&ndash;2012 (ranked 26th in the nation in 2012).</li>
+      </ul>
+    </section>
+
+    <section class="cv-section">
+      <h2>Talks</h2>
+      <ul class="cv-list">
+        <li>&ldquo;How to Safely Discard Features Based on Aggregate SHAP Values.&rdquo; COLT 2025.</li>
+        <li>&ldquo;Robust Empirical Risk Minimization with Tolerance.&rdquo; ALT 2023.</li>
+        <li>&ldquo;Online k-means Clustering on Arbitrary Data Streams.&rdquo; ALT 2023.</li>
+        <li>&ldquo;Learning What to Remember.&rdquo; ALT 2022.</li>
+        <li>&ldquo;No-substitution k-means Clustering with Adversarial Order.&rdquo; ALT 2021.</li>
+        <li>&ldquo;When are Non-Parametric Methods Robust?&rdquo; ICML 2020.</li>
+        <li>&ldquo;What Relations are Reliably Embeddable in Euclidean Space?&rdquo; ALT 2020.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,9 @@
             <a class="nav-link" href="publications.html">Publications</a>
           </li>
           <li class="nav-item">
+            <a class="nav-link" href="cv.html">CV</a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link" href="#contact">Contact</a>
           </li>
           <li class="nav-item">

--- a/jiujitsu.html
+++ b/jiujitsu.html
@@ -21,6 +21,9 @@
             <a class="nav-link" href="publications.html">Publications</a>
           </li>
           <li class="nav-item">
+            <a class="nav-link" href="cv.html">CV</a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link" href="index.html#contact">Contact</a>
           </li>
           <li class="nav-item active">

--- a/publications.html
+++ b/publications.html
@@ -21,6 +21,9 @@
           <a class="nav-link" href="publications.html">Publications</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="cv.html">CV</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="index.html#contact">Contact</a>
         </li>
         <li class="nav-item">

--- a/robitemplate.css
+++ b/robitemplate.css
@@ -208,3 +208,117 @@ img {
     text-align: left;
   }
 }
+
+.cv-page {
+  font-size: 1.05rem;
+}
+
+.cv-header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.cv-name {
+  font-size: 2.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.cv-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2rem;
+  color: #333;
+}
+
+.cv-meta p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.cv-meta a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.cv-meta a:hover,
+.cv-meta a:focus {
+  text-decoration: underline;
+}
+
+.cv-section {
+  margin-bottom: 2.75rem;
+}
+
+.cv-section h2 {
+  font-size: 1.6rem;
+  margin-bottom: 1.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.cv-entry {
+  margin-bottom: 1.75rem;
+}
+
+.cv-entry:last-child {
+  margin-bottom: 0;
+}
+
+.cv-entry-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.cv-entry-title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.cv-entry-role {
+  margin: 0.2rem 0 0;
+  font-style: italic;
+  color: #555;
+}
+
+.cv-entry-meta {
+  font-weight: 600;
+  color: #333;
+}
+
+.cv-entry-description {
+  margin: 0.5rem 0 0;
+}
+
+.cv-list {
+  list-style: disc;
+  margin: 0;
+  padding-left: 1.5rem;
+  color: #333;
+}
+
+.cv-list li {
+  margin-bottom: 0.75rem;
+}
+
+.cv-list li:last-child {
+  margin-bottom: 0;
+}
+
+@media (max-width: 575.98px) {
+  .cv-entry-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .cv-entry-meta {
+    text-align: left;
+  }
+
+  .cv-meta {
+    gap: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- create a dedicated `cv.html` page that mirrors the LaTeX/PDF CV content on the site
- add a CV link to the primary navigation across existing pages for consistent access
- style the CV layout to present sections, entries, and lists cleanly on the web

## Testing
- not run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68d84c5a47d4832098d1e25742ba96bb