### PR TITLE
Update index page blurbs

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     <div class="index-content-column">
       <div id="about" class="mb-4">
         <p>
-          I'm currently a chubbybubble at the Univeristy of Tubingen supervised by Ulrike von Luxburg. Previously, I completed my Phd at UC San Diego where I was fortunate to be co-advised by Kamalika Chaudhuri and Sanjoy Dasgupta. I'm broadly interested in various theoretical topics that fall under the umbrella of Trustworthy Machine Learning. Recently, I've been interested in studying basic problems in explainability. I've previously worked in adversarial robustness as well as online k-means clustering. I also like math, in which I receieved a B.S. from MIT in 2016.
+          I'm a postdoc at University of Tuebingen supervised by <a href="http://tml.cs.uni-tuebingen.de/team/luxburg/">Ulrike von Luxburg</a>. My research is broadly focused on developing theory that builds towards more robust and trustworthy machine learning system. I received my Phd from UCSD in 2023 where I was fortunate to be advised by <a href="https://cseweb.ucsd.edu/~kamalika/#">Kamalika Chaudhuri</a> and <a href="https://cseweb.ucsd.edu/~dasgupta/">Sanjoy Dasgupta</a>.
         </p>
       </div>
       <div id="research" class="mb-4">
@@ -52,7 +52,7 @@
         <div class="mb-3">
           <h3>Explainability and Interpretability</h3>
           <p>
-            A bit about this area of my research--
+            I've lately been very interested in studying how effective and reliable current explainability and interpretability tools are. Thus far, my approach has been to study older (but still widely applied tools) feature attribution methods. I'm especially pleased with our work on the popular method SHAP where we found some cute mathematics that shows a simple modification under which KernelSHAP enjoys some reasonably strong provable guarantees.
           </p>
           <ul class="fa-ul">
             <li>
@@ -78,7 +78,7 @@
         <div class="mb-3">
           <h3>Adversarial Robustness</h3>
           <p>
-            A bit about this area of my research--
+            One of the first problems I worked on was in understanding "adversarial examples," which are small imperceptible changes made a test-time designed to cause misclassification. The approach we took was to study this problem in the context of much more old fashioned machine learning techniques such as linear classifiers and non-parametrics. We found that some of the phenomena encountered in deep networks (such as differing sample complexities for learning robust classifiers rather than accurate ones) also occur in these simpler settings. We also found some simple ways to mitigate these issues including a modification under which non-parmetrics converge towards the optimally robust classifier.
           </p>
           <ul class="fa-ul">
             <li>
@@ -109,7 +109,7 @@
         </div>
         <div class="mb-3">
           <h3>Online Learning</h3>
-          <p>A bit about this area of my research--</p>
+          <p>I was introduced to online clustering by <a href="https://sites.google.com/view/michal-moshkovitz">Michal Moshkovitz</a> and immediately loved it for its simple setting and interesting algorithms. One of our main results was a simple efficient algorithm that nevertheless achieved an O(1) approximation to the optimal loss. Our main innovations were in efficiently  adjusting to data sequences where the relevant distance scale rapidly changes.</p>
           <ul class="fa-ul">
             <li>
               <span class="fa-li"><i class="fa-solid fa-link"></i></span>


### PR DESCRIPTION
## Summary
- refresh the lead blurb on the index page to highlight the new postdoctoral role and advisors
- expand the Explainability, Adversarial Robustness, and Online Learning sections with updated research descriptions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8553654848320a2fca9e22aaac10b