### PR TITLE
Add personal hobbies paragraph to about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -241,6 +241,7 @@
 
     <div class="content">
       <p>Hi, this is a paragraph about me, Robi Bhattacharjee.</p>
+      <p>When I'm not drawing dots, lines, triangles and circles in my notebook or staring off into math magic land, you can typically find me exclaiming at my computer screen over a Starcraft/Chess tournament. I also spend some time coaching a Brazilian Jiu Jitsu class once a week. Since I moved to Germany, I have been biking around, a lot. I've also been hiking a lot. I've been trying to learn how to cook and have pretty much mastered a beef stew. I haven't been disciplined about learning German, but my wife and I watched <em>Breaking Bad</em> in German and it still slapped. Plus now I know they say "Waffe" for "gun" and "Meth" for "meth," so I'm basically good to go.</p>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- add a new paragraph of personal details beneath the introductory text on the About page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d85963af8c8320b1affa4679050ae2