### PR TITLE
Align desktop header navigation with logo

### DIFF
--- a/about.html
+++ b/about.html
@@ -190,22 +190,22 @@
   </style>
 </head>
 <body class="playfair-font">
-  <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
-      <a class="navbar-brand" href="index.html">Robi Bhattacharjee</a>
-      <div class="collapse navbar-collapse" id="navbarText">
-        <ul class="navbar-nav">
-          <li class="nav-item">
-            <a class="nav-link" href="about.html">About</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="publications.html">Publications</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="cv.html">CV</a>
-          </li>
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a class="site-logo" href="index.html">Robi Bhattacharjee</a>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-navigation">
+        <span aria-hidden="true">&#9776;</span>
+        <span class="sr-only">Menu</span>
+      </button>
+      <nav class="site-nav" id="primary-navigation" aria-label="Primary" data-visible="false">
+        <ul class="site-nav__list">
+          <li><a class="site-nav__link" href="about.html" aria-current="page">About</a></li>
+          <li><a class="site-nav__link" href="publications.html">Publications</a></li>
+          <li><a class="site-nav__link" href="cv.html">CV</a></li>
         </ul>
-      </div>
-  </nav>
+      </nav>
+    </div>
+  </header>
   <div class="about-page">
     <div class="content">
       <h1>The Fun Stuff</h1>
@@ -518,6 +518,55 @@
       document.addEventListener('keydown', handleKeydown);
       track.addEventListener('touchstart', handleTouchStart, { passive: true });
       track.addEventListener('touchend', handleTouchEnd);
+    })();
+  </script>
+  <script>
+    (function () {
+      const navToggle = document.querySelector('.nav-toggle');
+      const nav = document.getElementById('primary-navigation');
+
+      if (!navToggle || !nav) {
+        return;
+      }
+
+      const openMenu = () => {
+        nav.dataset.visible = 'true';
+        navToggle.setAttribute('aria-expanded', 'true');
+      };
+
+      const closeMenu = () => {
+        nav.dataset.visible = 'false';
+        navToggle.setAttribute('aria-expanded', 'false');
+      };
+
+      navToggle.addEventListener('click', () => {
+        const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      nav.querySelectorAll('a').forEach((link) => {
+        link.addEventListener('click', () => {
+          if (window.innerWidth < 768) {
+            closeMenu();
+          }
+        });
+      });
+
+      const handleResize = () => {
+        if (window.innerWidth >= 768) {
+          nav.dataset.visible = 'true';
+          navToggle.setAttribute('aria-expanded', 'false');
+        } else if (navToggle.getAttribute('aria-expanded') === 'false') {
+          nav.dataset.visible = 'false';
+        }
+      };
+
+      handleResize();
+      window.addEventListener('resize', handleResize);
     })();
   </script>
 </body>

--- a/cv.html
+++ b/cv.html
@@ -10,22 +10,22 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 </head>
 <body class="playfair-font">
-  <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
-    <a class="navbar-brand" href="index.html">Robi Bhattacharjee</a>
-    <div class="collapse navbar-collapse" id="navbarText">
-      <ul class="navbar-nav">
-        <li class="nav-item">
-          <a class="nav-link" href="about.html">About</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="publications.html">Publications</a>
-        </li>
-        <li class="nav-item active">
-          <a class="nav-link" href="cv.html">CV</a>
-        </li>
-      </ul>
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a class="site-logo" href="index.html">Robi Bhattacharjee</a>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-navigation">
+        <span aria-hidden="true">&#9776;</span>
+        <span class="sr-only">Menu</span>
+      </button>
+      <nav class="site-nav" id="primary-navigation" aria-label="Primary" data-visible="false">
+        <ul class="site-nav__list">
+          <li><a class="site-nav__link" href="about.html">About</a></li>
+          <li><a class="site-nav__link" href="publications.html">Publications</a></li>
+          <li><a class="site-nav__link" href="cv.html" aria-current="page">CV</a></li>
+        </ul>
+      </nav>
     </div>
-  </nav>
+  </header>
 
   <main class="page-container cv-page">
     <header class="cv-header">
@@ -255,5 +255,54 @@
       </ul>
     </section>
   </main>
+  <script>
+    (function () {
+      const navToggle = document.querySelector('.nav-toggle');
+      const nav = document.getElementById('primary-navigation');
+
+      if (!navToggle || !nav) {
+        return;
+      }
+
+      const openMenu = () => {
+        nav.dataset.visible = 'true';
+        navToggle.setAttribute('aria-expanded', 'true');
+      };
+
+      const closeMenu = () => {
+        nav.dataset.visible = 'false';
+        navToggle.setAttribute('aria-expanded', 'false');
+      };
+
+      navToggle.addEventListener('click', () => {
+        const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      nav.querySelectorAll('a').forEach((link) => {
+        link.addEventListener('click', () => {
+          if (window.innerWidth < 768) {
+            closeMenu();
+          }
+        });
+      });
+
+      const handleResize = () => {
+        if (window.innerWidth >= 768) {
+          nav.dataset.visible = 'true';
+          navToggle.setAttribute('aria-expanded', 'false');
+        } else if (navToggle.getAttribute('aria-expanded') === 'false') {
+          nav.dataset.visible = 'false';
+        }
+      };
+
+      handleResize();
+      window.addEventListener('resize', handleResize);
+    })();
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,22 +14,22 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 </head>
 <body class="playfair-font">
-  <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
-      <a class="navbar-brand" href="index.html">Robi Bhattacharjee</a>
-      <div class="collapse navbar-collapse" id="navbarText">
-        <ul class="navbar-nav">
-          <li class="nav-item">
-            <a class="nav-link" href="about.html">About</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="publications.html">Publications</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="cv.html">CV</a>
-          </li>
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a class="site-logo" href="index.html">Robi Bhattacharjee</a>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-navigation">
+        <span aria-hidden="true">&#9776;</span>
+        <span class="sr-only">Menu</span>
+      </button>
+      <nav class="site-nav" id="primary-navigation" aria-label="Primary" data-visible="false">
+        <ul class="site-nav__list">
+          <li><a class="site-nav__link" href="about.html">About</a></li>
+          <li><a class="site-nav__link" href="publications.html">Publications</a></li>
+          <li><a class="site-nav__link" href="cv.html">CV</a></li>
         </ul>
-      </div>
-  </nav>
+      </nav>
+    </div>
+  </header>
 
   <div class="index-layout">
     <div class="index-image-column">
@@ -143,6 +143,56 @@
     </div>
   </div>
   <div id="scroll-padding"></div>
+
+  <script>
+    (function () {
+      const navToggle = document.querySelector('.nav-toggle');
+      const nav = document.getElementById('primary-navigation');
+
+      if (!navToggle || !nav) {
+        return;
+      }
+
+      const openMenu = () => {
+        nav.dataset.visible = 'true';
+        navToggle.setAttribute('aria-expanded', 'true');
+      };
+
+      const closeMenu = () => {
+        nav.dataset.visible = 'false';
+        navToggle.setAttribute('aria-expanded', 'false');
+      };
+
+      navToggle.addEventListener('click', () => {
+        const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      nav.querySelectorAll('a').forEach((link) => {
+        link.addEventListener('click', () => {
+          if (window.innerWidth < 768) {
+            closeMenu();
+          }
+        });
+      });
+
+      const handleResize = () => {
+        if (window.innerWidth >= 768) {
+          nav.dataset.visible = 'true';
+          navToggle.setAttribute('aria-expanded', 'false');
+        } else if (navToggle.getAttribute('aria-expanded') === 'false') {
+          nav.dataset.visible = 'false';
+        }
+      };
+
+      handleResize();
+      window.addEventListener('resize', handleResize);
+    })();
+  </script>
 
 </body>
 

--- a/publications.html
+++ b/publications.html
@@ -10,22 +10,22 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 </head>
 <body class="playfair-font">
-  <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
-    <a class="navbar-brand" href="index.html">Robi Bhattacharjee</a>
-    <div class="collapse navbar-collapse" id="navbarText">
-      <ul class="navbar-nav">
-        <li class="nav-item">
-          <a class="nav-link" href="about.html">About</a>
-        </li>
-        <li class="nav-item active">
-          <a class="nav-link" href="publications.html">Publications</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="cv.html">CV</a>
-        </li>
-      </ul>
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a class="site-logo" href="index.html">Robi Bhattacharjee</a>
+      <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-navigation">
+        <span aria-hidden="true">&#9776;</span>
+        <span class="sr-only">Menu</span>
+      </button>
+      <nav class="site-nav" id="primary-navigation" aria-label="Primary" data-visible="false">
+        <ul class="site-nav__list">
+          <li><a class="site-nav__link" href="about.html">About</a></li>
+          <li><a class="site-nav__link" href="publications.html" aria-current="page">Publications</a></li>
+          <li><a class="site-nav__link" href="cv.html">CV</a></li>
+        </ul>
+      </nav>
     </div>
-  </nav>
+  </header>
 
   <main class="page-container">
     <h1 class="page-title">Publications</h1>
@@ -251,5 +251,54 @@
       </ul>
     </section>
   </main>
+  <script>
+    (function () {
+      const navToggle = document.querySelector('.nav-toggle');
+      const nav = document.getElementById('primary-navigation');
+
+      if (!navToggle || !nav) {
+        return;
+      }
+
+      const openMenu = () => {
+        nav.dataset.visible = 'true';
+        navToggle.setAttribute('aria-expanded', 'true');
+      };
+
+      const closeMenu = () => {
+        nav.dataset.visible = 'false';
+        navToggle.setAttribute('aria-expanded', 'false');
+      };
+
+      navToggle.addEventListener('click', () => {
+        const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+        if (expanded) {
+          closeMenu();
+        } else {
+          openMenu();
+        }
+      });
+
+      nav.querySelectorAll('a').forEach((link) => {
+        link.addEventListener('click', () => {
+          if (window.innerWidth < 768) {
+            closeMenu();
+          }
+        });
+      });
+
+      const handleResize = () => {
+        if (window.innerWidth >= 768) {
+          nav.dataset.visible = 'true';
+          navToggle.setAttribute('aria-expanded', 'false');
+        } else if (navToggle.getAttribute('aria-expanded') === 'false') {
+          nav.dataset.visible = 'false';
+        }
+      };
+
+      handleResize();
+      window.addEventListener('resize', handleResize);
+    })();
+  </script>
 </body>
 </html>

--- a/robitemplate.css
+++ b/robitemplate.css
@@ -6,6 +6,125 @@ body {
   font-size: 1.2rem !important;
 }
 
+.site-header {
+  background-color: #f8f9fa;
+  border-bottom: 1px solid #e0e0e0;
+  margin-bottom: 2rem;
+}
+
+.site-header__inner {
+  max-width: 960px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.site-logo {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #454545;
+  text-decoration: none;
+}
+
+.site-logo:focus-visible,
+.site-logo:hover {
+  text-decoration: underline;
+}
+
+.nav-toggle {
+  background: none;
+  border: 0;
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #333;
+  padding: 0.25rem;
+}
+
+.nav-toggle:focus-visible {
+  outline: 2px solid #1f3c88;
+  outline-offset: 2px;
+}
+
+.site-nav {
+  order: 3;
+  flex-basis: 100%;
+}
+
+.site-nav[data-visible="false"] {
+  display: none;
+}
+
+.site-nav[data-visible="true"] {
+  display: block;
+  width: 100%;
+  padding-bottom: 1rem;
+}
+
+.site-nav__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.site-nav__link {
+  color: #333;
+  text-decoration: none;
+  font-size: 1.1rem;
+}
+
+.site-nav__link:focus-visible,
+.site-nav__link:hover {
+  text-decoration: underline;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (min-width: 768px) {
+  .site-header__inner {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+  }
+
+  .site-logo {
+    flex: 0 0 auto;
+  }
+
+  .nav-toggle {
+    display: none;
+  }
+
+  .site-nav {
+    order: 2;
+    flex: 0 0 auto;
+    display: block !important;
+    padding-bottom: 0;
+  }
+
+  .site-nav__list {
+    flex-direction: row;
+    gap: 1.5rem;
+  }
+}
+
 .playfair-font {
   font-family: "Playfair Display", serif;
 }


### PR DESCRIPTION
## Summary
- adjust the desktop header layout to keep navigation links immediately after the site name
- prevent the navigation list from being right-aligned at the desktop breakpoint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8fdb6f6388320a0056cc93c9a5fb4