### PR TITLE
Adjust navigation heading styling for desktop alignment

### DIFF
--- a/robitemplate.css
+++ b/robitemplate.css
@@ -76,9 +76,9 @@ body {
 }
 
 .site-nav__link {
-  color: #333;
+  color: #6b6b6b;
   text-decoration: none;
-  font-size: 1.1rem;
+  font-size: calc(1.5rem - 4pt);
 }
 
 .site-nav__link:focus-visible,
@@ -102,6 +102,7 @@ body {
   .site-header__inner {
     flex-wrap: nowrap;
     justify-content: flex-start;
+    align-items: baseline;
   }
 
   .site-logo {
@@ -122,6 +123,7 @@ body {
   .site-nav__list {
     flex-direction: row;
     gap: 1.5rem;
+    align-items: baseline;
   }
 }
 


### PR DESCRIPTION
## Summary
- reduce the navigation link font size to sit four points below the site title and lighten their color
- align the desktop navigation list with the site title so the links share the same baseline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d905550b1c83208b4e1dbf8401a715