### PR TITLE
Update CV contact info and rearrange sections

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -33,8 +33,6 @@
       <div class="cv-meta">
         <div>
           <p><strong>Contact</strong><br>
-            28 Quenstedtstrasse<br>
-            Tübingen 72076, Germany<br>
             <a href="mailto:robibhatt@gmail.com">robibhatt@gmail.com</a><br>
             <a href="https://robibhatt.github.io">robibhatt.github.io</a><br>
             <a href="https://github.com/robibhatt">github.com/robibhatt</a>
@@ -215,21 +213,15 @@
     </section>
 
     <section class="cv-section">
-      <h2>Service</h2>
+      <h2>Talks</h2>
       <ul class="cv-list">
-        <li>Reviewer, NeurIPS 2025.</li>
-        <li>Reviewer, ICLR 2025.</li>
-        <li>Reviewer, ALT 2025.</li>
-        <li>Reviewer, ICML 2025.</li>
-        <li>Reviewer, NeurIPS 2024.</li>
-        <li>Reviewer, ICML 2024.</li>
-        <li>Reviewer, ICML 2023.</li>
-        <li>Reviewer, ICML 2022.</li>
-        <li>Reviewer, ICML 2021.</li>
-        <li>Reviewer, JMLR 2021.</li>
-        <li>Reviewer, AISTATS 2020.</li>
-        <li>Mentor for UCSD Graduate Women in Computing (Fall 2020 &ndash; Winter 2021).</li>
-        <li>Geometry teacher for MISE foundation (Winter &ndash; Summer 2021).</li>
+        <li>&ldquo;How to Safely Discard Features Based on Aggregate SHAP Values.&rdquo; COLT 2025.</li>
+        <li>&ldquo;Robust Empirical Risk Minimization with Tolerance.&rdquo; ALT 2023.</li>
+        <li>&ldquo;Online k-means Clustering on Arbitrary Data Streams.&rdquo; ALT 2023.</li>
+        <li>&ldquo;Learning What to Remember.&rdquo; ALT 2022.</li>
+        <li>&ldquo;No-substitution k-means Clustering with Adversarial Order.&rdquo; ALT 2021.</li>
+        <li>&ldquo;When are Non-Parametric Methods Robust?&rdquo; ICML 2020.</li>
+        <li>&ldquo;What Relations are Reliably Embeddable in Euclidean Space?&rdquo; ALT 2020.</li>
       </ul>
     </section>
 
@@ -244,15 +236,21 @@
     </section>
 
     <section class="cv-section">
-      <h2>Talks</h2>
+      <h2>Service</h2>
       <ul class="cv-list">
-        <li>&ldquo;How to Safely Discard Features Based on Aggregate SHAP Values.&rdquo; COLT 2025.</li>
-        <li>&ldquo;Robust Empirical Risk Minimization with Tolerance.&rdquo; ALT 2023.</li>
-        <li>&ldquo;Online k-means Clustering on Arbitrary Data Streams.&rdquo; ALT 2023.</li>
-        <li>&ldquo;Learning What to Remember.&rdquo; ALT 2022.</li>
-        <li>&ldquo;No-substitution k-means Clustering with Adversarial Order.&rdquo; ALT 2021.</li>
-        <li>&ldquo;When are Non-Parametric Methods Robust?&rdquo; ICML 2020.</li>
-        <li>&ldquo;What Relations are Reliably Embeddable in Euclidean Space?&rdquo; ALT 2020.</li>
+        <li>Reviewer, NeurIPS 2025.</li>
+        <li>Reviewer, ICLR 2025.</li>
+        <li>Reviewer, ALT 2025.</li>
+        <li>Reviewer, ICML 2025.</li>
+        <li>Reviewer, NeurIPS 2024.</li>
+        <li>Reviewer, ICML 2024.</li>
+        <li>Reviewer, ICML 2023.</li>
+        <li>Reviewer, ICML 2022.</li>
+        <li>Reviewer, ICML 2021.</li>
+        <li>Reviewer, JMLR 2021.</li>
+        <li>Reviewer, AISTATS 2020.</li>
+        <li>Mentor for UCSD Graduate Women in Computing (Fall 2020 &ndash; Winter 2021).</li>
+        <li>Geometry teacher for MISE foundation (Winter 2020 &ndash; Summer 2021).</li>
       </ul>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- remove the physical address from the CV contact information
- reorder the Talks and Service sections while keeping Honors and Awards between them
- adjust the MISE foundation teaching entry to show the correct Winter 2020 – Summer 2021 dates

## Testing
- No tests were run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68d913ff620c8320978f17a5f20dd637