### PR TITLE
Reduce scroll padding height on index page

### DIFF
--- a/robitemplate.css
+++ b/robitemplate.css
@@ -169,7 +169,7 @@ img {
 }
 
 #scroll-padding {
-  height: 95vh;
+  height: 10vh;
 }
 
 .index-layout {


### PR DESCRIPTION
## Summary
- shrink the `#scroll-padding` element height to 10vh so the index page ends closer to the final content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d91b7550a083208e66acd5a6265eda