### PR TITLE
Center about page intro paragraph

### DIFF
--- a/about.html
+++ b/about.html
@@ -164,6 +164,21 @@
       color: #333;
     }
 
+    .entertainment-section {
+      text-align: left;
+    }
+
+    .entertainment-section p {
+      text-align: left;
+    }
+
+    .entertainment-title {
+      font-size: 1.75rem;
+      font-style: italic;
+      margin: 1.5rem 0 0.75rem;
+      text-align: left;
+    }
+
     @media (min-width: 640px) {
       .carousel {
         --visible-slides: 2.2;
@@ -241,7 +256,10 @@
 
     <div class="content">
       <p>When I'm not doing math, you can typically find me exclaiming at my computer screen over a Starcraft/chess tournament. I also spend some time coaching a Brazilian Jiu Jitsu class once a week. Since I moved to Germany, I have been biking around, a lot. I've also been hiking a lot. I've been trying to learn how to cook and have pretty much mastered a beef stew. I haven't been disciplined about learning German, but my wife and I watched <em>Breaking Bad</em> in German and it still slapped. Plus now I know they say "Waffe" for "gun" and "Meth" for "meth," so I'm basically good to go.</p>
-      <p>Entertainment--</p>
+    </div>
+
+    <div class="content entertainment-section">
+      <h3 class="entertainment-title"><span>Entertainment&#8212;</span></h3>
       <p>It's hard to pick favorites, but right now here are a few of my favorite things:</p>
       <p>Books: Pachinko by Min Jin Lee, Yellowface by R.F. Kuang</p>
       <p>Movies: Inglorious Basterds, Midnight in Paris, Arrival</p>


### PR DESCRIPTION
## Summary
- separate the about page intro paragraph from the Entertainment section container
- allow the intro text to remain centered while keeping the Entertainment list left-aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d92eacd0d48320b86e14372707ff20