### PR TITLE
Scope talk video anchors to icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,20 +60,32 @@
           </p>
           <ul class="fa-ul">
             <li>
-              <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              <a href="https://arxiv.org/abs/2508.11441" target="_blank" rel="noopener noreferrer">Informative Post-Hoc Explanations Only Exist for Simple Functions</a><br>
+              <span class="fa-li">
+                <a href="https://arxiv.org/abs/2508.11441" target="_blank" rel="noopener noreferrer">
+                  <i class="fa-solid fa-circle-play"></i>
+                </a>
+              </span>
+              Informative Post-Hoc Explanations Only Exist for Simple Functions<br>
               E Günther, B Szabados, <strong>R Bhattacharjee</strong>, S Bordt, U von Luxburg <br>
               In Preparation
             </li>
             <li>
-              <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              <a href="https://arxiv.org/abs/2503.23111" target="_blank" rel="noopener noreferrer">How to safely discard features based on aggregate SHAP values</a><br>
+              <span class="fa-li">
+                <a href="https://arxiv.org/abs/2503.23111" target="_blank" rel="noopener noreferrer">
+                  <i class="fa-solid fa-circle-play"></i>
+                </a>
+              </span>
+              How to safely discard features based on aggregate SHAP values<br>
               <strong>R Bhattacharjee</strong>, K Frohnapfel, U von Luxburg <br>
               COLT 2025
             </li>
             <li>
-              <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              <a href="https://arxiv.org/abs/2407.13281" target="_blank" rel="noopener noreferrer">Auditing local explanations is hard</a><br>
+              <span class="fa-li">
+                <a href="https://arxiv.org/abs/2407.13281" target="_blank" rel="noopener noreferrer">
+                  <i class="fa-solid fa-circle-play"></i>
+                </a>
+              </span>
+              Auditing local explanations is hard<br>
               <strong>R Bhattacharjee</strong>, U Luxburg <br>
               Neurips 2024
             </li>
@@ -86,26 +98,42 @@
           </p>
           <ul class="fa-ul">
             <li>
-              <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              <a href="https://arxiv.org/abs/2210.00635" target="_blank" rel="noopener noreferrer">Robust Empirical Risk Minimization with Tolerance</a><br>
+              <span class="fa-li">
+                <a href="https://arxiv.org/abs/2210.00635" target="_blank" rel="noopener noreferrer">
+                  <i class="fa-solid fa-circle-play"></i>
+                </a>
+              </span>
+              Robust Empirical Risk Minimization with Tolerance<br>
               <strong>R Bhattacharjee</strong>, M Hopkins, A Kumar, H Yu, K Chaudhuri<br>
               ALT 2023
             </li>
             <li>
-              <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              <a href="https://arxiv.org/abs/2102.09086" target="_blank" rel="noopener noreferrer">Consistent Non-Parametric Methods for Maximizing Robustness</a><br>
+              <span class="fa-li">
+                <a href="https://arxiv.org/abs/2102.09086" target="_blank" rel="noopener noreferrer">
+                  <i class="fa-solid fa-circle-play"></i>
+                </a>
+              </span>
+              Consistent Non-Parametric Methods for Maximizing Robustness<br>
               <strong>R Bhattacharjee</strong>, K Chaudhuri<br>
               Neurips 2021
             </li>
             <li>
-              <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              <a href="https://arxiv.org/abs/2012.10794" target="_blank" rel="noopener noreferrer">Sample Complexity of Adversarially Robust Linear Classification on Separated Data</a><br>
+              <span class="fa-li">
+                <a href="https://arxiv.org/abs/2012.10794" target="_blank" rel="noopener noreferrer">
+                  <i class="fa-solid fa-circle-play"></i>
+                </a>
+              </span>
+              Sample Complexity of Adversarially Robust Linear Classification on Separated Data<br>
               <strong>R Bhattacharjee</strong>, S Jha, K Chaudhuri<br>
               ICML 2021
             </li>
             <li>
-              <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              <a href="https://arxiv.org/abs/2003.06121" target="_blank" rel="noopener noreferrer">When are Non-Parametric Methods Robust?</a><br>
+              <span class="fa-li">
+                <a href="https://arxiv.org/abs/2003.06121" target="_blank" rel="noopener noreferrer">
+                  <i class="fa-solid fa-circle-play"></i>
+                </a>
+              </span>
+              When are Non-Parametric Methods Robust?<br>
               <strong>R Bhattacharjee</strong>, K Chaudhuri<br>
               ICML 2020
             </li>
@@ -116,20 +144,32 @@
           <p>I was introduced to online clustering by <a href="https://sites.google.com/view/michal-moshkovitz" target="_blank" rel="noopener noreferrer">Michal Moshkovitz</a> and immediately loved it for its simple setting and interesting algorithms. One of our main results was a simple efficient algorithm that nevertheless achieved an O(1) approximation to the optimal loss. Our main innovations were in efficiently  adjusting to data sequences where the relevant distance scale rapidly changes.</p>
           <ul class="fa-ul">
             <li>
-              <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              <a href="https://arxiv.org/abs/2102.09101" target="_blank" rel="noopener noreferrer">Online k-means Clustering on Arbitrary Data Streams</a><br>
+              <span class="fa-li">
+                <a href="https://arxiv.org/abs/2102.09101" target="_blank" rel="noopener noreferrer">
+                  <i class="fa-solid fa-circle-play"></i>
+                </a>
+              </span>
+              Online k-means Clustering on Arbitrary Data Streams<br>
               <strong>R Bhattacharjee</strong>, J Imola, M Moshkovitz, S Dasgupta<br>
               ALT 2023
             </li>
             <li>
-              <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              <a href="https://arxiv.org/abs/2201.03806" target="_blank" rel="noopener noreferrer">Learning what to remember</a><br>
+              <span class="fa-li">
+                <a href="https://arxiv.org/abs/2201.03806" target="_blank" rel="noopener noreferrer">
+                  <i class="fa-solid fa-circle-play"></i>
+                </a>
+              </span>
+              Learning what to remember<br>
               <strong>R Bhattacharjee</strong>, G Mahajan<br>
               ALT 2022
             </li>
             <li>
-              <span class="fa-li"><i class="fa-solid fa-link"></i></span>
-              <a href="https://arxiv.org/abs/2012.14512" target="_blank" rel="noopener noreferrer">No-substitution k-means Clustering with Adversarial Order</a><br>
+              <span class="fa-li">
+                <a href="https://arxiv.org/abs/2012.14512" target="_blank" rel="noopener noreferrer">
+                  <i class="fa-solid fa-circle-play"></i>
+                </a>
+              </span>
+              No-substitution k-means Clustering with Adversarial Order<br>
               <strong>R Bhattacharjee</strong>, M Moshkovitz<br>
               ALT 2021
             </li>


### PR DESCRIPTION
## Summary
- wrap each talk video link around only the play icon in the Explainability, Adversarial Robustness, and Online Learning lists
- leave the talk descriptions as plain text so only the play icon remains clickable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d93a74556c8320ae6426da1b3303a4