### PR TITLE
Add video talk links to research sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,16 @@
               <strong>R Bhattacharjee</strong>, U Luxburg <br>
               Neurips 2024
             </li>
+            <li>
+              <span class="fa-li"><i class="fa-solid fa-circle-play"></i></span>
+              <a href="https://youtu.be/40XZ_QAU1Mw?si=9mXiXAYUPgs0TUUA" target="_blank" rel="noopener noreferrer">Watch the talk</a>
+              &mdash; Talk I gave at the <a href="https://tverven.github.io/tiai-seminar/" target="_blank" rel="noopener noreferrer">Interpretability Seminar</a> about our work on (the difficulty in) auditing local explanations. 2025
+            </li>
+            <li>
+              <span class="fa-li"><i class="fa-solid fa-circle-play"></i></span>
+              <a href="https://youtu.be/Yy8t073miIw?si=K_w_NOenV00mZM3X&t=4281" target="_blank" rel="noopener noreferrer">Watch the talk</a>
+              &mdash; Talk at COLT I gave about our work on the SHAP explainability method. Talk starts a 1:11:21. 2025
+            </li>
           </ul>
         </div>
         <div class="mb-3">
@@ -109,6 +119,11 @@
               <strong>R Bhattacharjee</strong>, K Chaudhuri<br>
               ICML 2020
             </li>
+            <li>
+              <span class="fa-li"><i class="fa-solid fa-circle-play"></i></span>
+              <a href="https://slideslive.com/38927958/when-are-nonparametric-methods-robust" target="_blank" rel="noopener noreferrer">Watch the presentation</a>
+              &mdash; A poster presentation I gave about our work on non-parametric methods for robustness. 2020
+            </li>
           </ul>
         </div>
         <div class="mb-3">
@@ -132,6 +147,11 @@
               <a href="https://arxiv.org/abs/2012.14512" target="_blank" rel="noopener noreferrer">No-substitution k-means Clustering with Adversarial Order</a><br>
               <strong>R Bhattacharjee</strong>, M Moshkovitz<br>
               ALT 2021
+            </li>
+            <li>
+              <span class="fa-li"><i class="fa-solid fa-circle-play"></i></span>
+              <a href="https://www.youtube.com/watch?v=iqfdIYaqasg" target="_blank" rel="noopener noreferrer">Watch the talk</a>
+              &mdash; Talk I gave at USC about our work on online clustering. 2023
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- add recent explainability talks with video and seminar links
- highlight robustness poster presentation recording
- link to online clustering talk video in the online learning section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d93ea859bc83209a68073febf94e87