### PR TITLE
Add GitHub link to contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,8 @@
         <i class="fa-solid fa-envelope" aria-hidden="true"></i>
         <span class="sr-only">Email:</span>
         robibhatt at gmail dot com <br>
+        <i class="fa-brands fa-github" aria-hidden="true"></i>
+        <a href="https://github.com/robibhatt" target="_blank" rel="noopener noreferrer">https://github.com/robibhatt</a> <br>
         <i class="fa-solid fa-user-graduate" aria-hidden="true"></i>
         <a href="https://scholar.google.com/citations?user=zB23BxYAAAAJ&hl=en" target="_blank" rel="noopener noreferrer">Google Scholar</a> <br>
         <i class="fa-solid fa-file" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary
- add a GitHub icon and profile link to the index page contact section

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d944c7262c8320871b116c4e7eb09d