### PR TITLE
Update about page cards with local images

### DIFF
--- a/about.html
+++ b/about.html
@@ -194,17 +194,24 @@
       border-radius: 14px;
       box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
       padding: 1.25rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .ac-card-header {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding-bottom: 0.25rem;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    }
+
+    .ac-card-content {
       display: grid;
       grid-template-columns: minmax(96px, 140px) 1fr;
       gap: 1rem;
       align-items: center;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      .ac-card {
-        background: rgba(34, 34, 34, 0.92);
-        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4);
-      }
     }
 
     .ac-cover {
@@ -261,7 +268,7 @@
         padding-right: 0;
       }
 
-      .ac-card {
+      .ac-card-content {
         grid-template-columns: 1fr;
         text-align: left;
       }
@@ -368,62 +375,86 @@
         <h2 class="content-title" id="about-interests-heading">Currently on My Radar</h2>
         <div class="ac-grid" role="list">
           <article class="ac-card" role="listitem">
-            <div class="ac-cover">
-              <img src="https://covers.openlibrary.org/b/isbn/9781455563920-L.jpg" alt="Cover of Pachinko by Min Jin Lee">
-            </div>
-            <div class="ac-body">
+            <header class="ac-card-header">
               <h3 class="ac-title">Books</h3>
-              <p class="ac-note"><strong>Pachinko</strong> by Min Jin Lee and <strong>Yellowface</strong> by R. F. Kuang.</p>
+            </header>
+            <div class="ac-card-content">
+              <div class="ac-cover">
+                <img src="fun_content/pachinko.jpeg" alt="Cover of Pachinko by Min Jin Lee">
+              </div>
+              <div class="ac-body">
+                <p class="ac-note"><strong>Pachinko</strong> by Min Jin Lee and <strong>Yellowface</strong> by R. F. Kuang.</p>
+              </div>
             </div>
           </article>
 
           <article class="ac-card" role="listitem">
-            <div class="ac-cover">
-              <img src="https://image.tmdb.org/t/p/w342/xGUOfDHmfyaBv6ARynsUe3lsmaB.jpg" alt="Poster for the film Arrival">
-            </div>
-            <div class="ac-body">
+            <header class="ac-card-header">
               <h3 class="ac-title">Movies</h3>
-              <p class="ac-note"><strong>Arrival</strong>, <strong>Inglourious Basterds</strong>, and <strong>Midnight in Paris</strong>.</p>
+            </header>
+            <div class="ac-card-content">
+              <div class="ac-cover">
+                <img src="fun_content/arrival.jpeg" alt="Poster for the film Arrival">
+              </div>
+              <div class="ac-body">
+                <p class="ac-note"><strong>Arrival</strong>, <strong>Inglourious Basterds</strong>, and <strong>Midnight in Paris</strong>.</p>
+              </div>
             </div>
           </article>
 
           <article class="ac-card" role="listitem">
-            <div class="ac-cover">
-              <img src="https://images.unsplash.com/photo-1598387577962-1d91e4bc3cda?auto=format&fit=crop&w=500&q=80" alt="A tiger standing in tall grass">
-            </div>
-            <div class="ac-body">
+            <header class="ac-card-header">
               <h3 class="ac-title">Animals</h3>
-              <p class="ac-note"><strong>Tigers</strong> and, more broadly, most land mammalian carnivores.</p>
+            </header>
+            <div class="ac-card-content">
+              <div class="ac-cover">
+                <img src="fun_content/tiger.jpeg" alt="A tiger standing in tall grass">
+              </div>
+              <div class="ac-body">
+                <p class="ac-note"><strong>Tigers</strong> and, more broadly, most land mammalian carnivores.</p>
+              </div>
             </div>
           </article>
 
           <article class="ac-card" role="listitem">
-            <div class="ac-cover">
-              <img src="https://images.igdb.com/igdb/image/upload/t_cover_big/co6azr.webp" alt="Poster art for the video game Hades">
-            </div>
-            <div class="ac-body">
+            <header class="ac-card-header">
               <h3 class="ac-title">Games</h3>
-              <p class="ac-note"><strong>Baldur’s Gate 3</strong>; <strong>Divinity: Original Sin 2</strong>; <strong>Hades I &amp; II</strong>; <strong>StarCraft I &amp; II</strong>.</p>
+            </header>
+            <div class="ac-card-content">
+              <div class="ac-cover">
+                <img src="fun_content/hades.jpeg" alt="Poster art for the video game Hades">
+              </div>
+              <div class="ac-body">
+                <p class="ac-note"><strong>Baldur’s Gate 3</strong>; <strong>Divinity: Original Sin 2</strong>; <strong>Hades I &amp; II</strong>; <strong>StarCraft I &amp; II</strong>.</p>
+              </div>
             </div>
           </article>
 
           <article class="ac-card" role="listitem">
-            <div class="ac-cover">
-              <img src="https://images.unsplash.com/photo-1516009081684-b4230e13ae8d?auto=format&fit=crop&w=500&q=80" alt="An orange basketball resting on an outdoor court">
-            </div>
-            <div class="ac-body">
+            <header class="ac-card-header">
               <h3 class="ac-title">Sports to Play</h3>
-              <p class="ac-note"><strong>Brazilian Jiu-Jitsu</strong>, <strong>bouldering</strong>, and <strong>basketball</strong>.</p>
+            </header>
+            <div class="ac-card-content">
+              <div class="ac-cover">
+                <img src="fun_content/basketball.jpeg" alt="An orange basketball resting on an outdoor court">
+              </div>
+              <div class="ac-body">
+                <p class="ac-note"><strong>Brazilian Jiu-Jitsu</strong>, <strong>bouldering</strong>, and <strong>basketball</strong>.</p>
+              </div>
             </div>
           </article>
 
           <article class="ac-card" role="listitem">
-            <div class="ac-cover">
-              <img src="https://images.unsplash.com/photo-1522778119026-d647f0596c20?auto=format&fit=crop&w=500&q=80" alt="Lionel Messi celebrating a goal">
-            </div>
-            <div class="ac-body">
+            <header class="ac-card-header">
               <h3 class="ac-title">Sports to Watch</h3>
-              <p class="ac-note"><strong>MMA</strong> and <strong>soccer</strong> (only during the World Cup).</p>
+            </header>
+            <div class="ac-card-content">
+              <div class="ac-cover">
+                <img src="fun_content/messi.jpeg" alt="Lionel Messi celebrating a goal">
+              </div>
+              <div class="ac-body">
+                <p class="ac-note"><strong>MMA</strong> and <strong>soccer</strong> (only during the World Cup).</p>
+              </div>
             </div>
           </article>
         </div>


### PR DESCRIPTION
## Summary
- use local fun_content images across the "Currently on My Radar" cards
- add in-card headers so the titles appear above each card's content and keep white backgrounds

## Testing
- python3 -m http.server 8000 (manually verified with Playwright screenshot)

------
https://chatgpt.com/codex/tasks/task_e_68d9574519d083209ce224bca94e122e