### PR TITLE
Add custom bullets and hover tilt to about page cards

### DIFF
--- a/about.html
+++ b/about.html
@@ -232,6 +232,12 @@
       height: 100%;
       object-fit: cover;
       display: block;
+      transition: transform 0.3s ease;
+    }
+
+    .ac-cover:hover img,
+    .ac-cover:focus-within img {
+      transform: rotate(-20deg);
     }
 
     .ac-cover--emoji {
@@ -251,15 +257,27 @@
 
     .ac-note {
       margin: 0;
-      padding-left: 1.25rem;
+      padding-left: 0;
       color: #000;
       font-size: 1rem;
       line-height: 1.5;
-      list-style: disc;
+      list-style: none;
     }
 
     .ac-note li {
+      position: relative;
+      padding-left: 1.5rem;
       margin-bottom: 0.25rem;
+    }
+
+    .ac-note li::before {
+      content: "\25B6";
+      position: absolute;
+      left: 0;
+      top: 0.55em;
+      transform: translateY(-50%);
+      color: #b0b0b0;
+      font-size: 0.75rem;
     }
 
     .ac-note li:last-child {


### PR DESCRIPTION
## Summary
- replace disc bullets in the about page cards with custom light grey triangle markers
- add a hover interaction to tilt the card images 20 degrees to the left for visual dynamism

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d962615ff0832084c9a18d8c4f49c1