### PR TITLE
Adjust card styling on about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -219,7 +219,7 @@
       aspect-ratio: 3 / 4;
       border-radius: 10px;
       overflow: hidden;
-      background: #f2f4f7;
+      background: #fff;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -274,7 +274,7 @@
       content: "\25B6";
       position: absolute;
       left: 0;
-      top: 0.6em;
+      top: 0.8em;
       transform: translateY(-50%);
       color: #b0b0b0;
       font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- set the about page card image backdrop to white to remove the gray tint
- lower the triangle bullet indicator so the point aligns with the list text

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d96601e91883209f7784d34f6f2dca