### PR TITLE
Adjust research heading spacing and font sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,8 @@
       </div>
       <div id="research" class="mb-4">
         <h2>Research</h2>
-        <div class="mb-3">
-          <h3>Explainability and Interpretability</h3>
+        <div class="mb-3 mt-3">
+          <h3 class="research-topic-title">Explainability and Interpretability</h3>
           <p>
             I've lately been very interested in studying how effective and reliable current explainability and interpretability tools are. Thus far, my approach has been to study older (but still widely applied tools) feature attribution methods. I'm especially pleased with our work on the popular method SHAP where we found some cute mathematics that shows a simple modification under which KernelSHAP enjoys some reasonably strong provable guarantees.
           </p>
@@ -92,7 +92,7 @@
           </ul>
         </div>
         <div class="mb-3">
-          <h3>Adversarial Robustness</h3>
+          <h3 class="research-topic-title">Adversarial Robustness</h3>
           <p>
             One of the first problems I worked on was in understanding "adversarial examples," which are small imperceptible changes made a test-time designed to cause misclassification. The approach we took was to study this problem in the context of much more old fashioned machine learning techniques such as linear classifiers and non-parametrics. We found that some of the phenomena encountered in deep networks (such as differing sample complexities for learning robust classifiers rather than accurate ones) also occur in these simpler settings. We also found some simple ways to mitigate these issues including a modification under which non-parmetrics converge towards the optimally robust classifier.
           </p>
@@ -129,7 +129,7 @@
           </ul>
         </div>
         <div class="mb-3">
-          <h3>Online Learning</h3>
+          <h3 class="research-topic-title">Online Learning</h3>
           <p>I was introduced to online clustering by <a href="https://sites.google.com/view/michal-moshkovitz" target="_blank" rel="noopener noreferrer">Michal Moshkovitz</a> and immediately loved it for its simple setting and interesting algorithms. One of our main results was a simple efficient algorithm that nevertheless achieved an O(1) approximation to the optimal loss. Our main innovations were in efficiently  adjusting to data sequences where the relevant distance scale rapidly changes.</p>
           <ul class="fa-ul">
             <li>

--- a/robitemplate.css
+++ b/robitemplate.css
@@ -195,6 +195,10 @@ img {
   margin-top: 2rem;
 }
 
+.research-topic-title {
+  font-size: 20pt;
+}
+
 .index-content-column {
   flex: 1 1 0;
   max-width: 100%;


### PR DESCRIPTION
## Summary
- add extra spacing between the Research header and the first topic on the homepage
- reduce the font size of the research topic headings by one point via a shared CSS class

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d997ad3d308320a79d7d6b37664fd0